### PR TITLE
Add Exun 2021-2022

### DIFF
--- a/js/competitions.json
+++ b/js/competitions.json
@@ -1543,6 +1543,14 @@
          "prize": "$30,000",
          "platform": "MIT",
          "sponsor": "Jump, Symbotic and others"
+     }, {
+         "name": "Exun 2021-2022 - Machine Learning",
+         "url": "https://exunclan.com",
+         "type": "🤷 Interdisciplinary (Unconventional)",
+         "deadline": "13 Jan 2022",
+         "prize": "$2000",
+         "platform": "Kaggle",
+         "sponsor": "Plaksha University, CodeChef"
      }]
 
  }


### PR DESCRIPTION
Exun Clan is Delhi Public School, R.K Puram’s computer and technology society, and Exun 2021-2022 is the 26th iteration of our annual school-level technology symposium. The symposium involves 20+ competitions open to high/middle schools globally. You can find complete descriptions of competitions on https://reg.exun.co/invite/events. One of the competitions is Machine Learning — where teams of up to 4 students can participate. Multiple subjective tasks covering various ML paradigms will be released on the 11th January, 12:00:00 IST, and the teams can submit their solutions by 13th January 12:00:00 IST.